### PR TITLE
magick_rust: disable hdri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]      # Creates dynamic lib
 
 [dependencies]
 miniserde = "0.1"
-magick_rust = "0.15"
+magick_rust = {version="0.15", features=["disable-hdri"]}
 regex = "1.5.4"
 sha2 = "0.10"
 which = "4"


### PR DESCRIPTION
thanks for the project.

closes #2 

this PR implements the workaround mentioned in https://github.com/nlfiedler/magick-rust/issues/40 to fix the problem compiling.
